### PR TITLE
Add Unique Idea View For Known User

### DIFF
--- a/app/controllers/idea_viewers_controller.rb
+++ b/app/controllers/idea_viewers_controller.rb
@@ -1,0 +1,26 @@
+class IdeaViewersController < ApplicationController
+  before_action :set_idea, only: %i[index]
+  # before_action :ensure_idea_owner, only: %i[show]
+
+  def index
+    @idea_viewers = @idea.viewers
+  end
+
+  def show
+    @idea_viewer = Viewer.find_by(id: params[:id])
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_idea
+    @idea = Idea.find(params[:idea_id])
+  end
+
+  def ensure_idea_owner
+    raise StandardError if @idea.user.id != current_user.id
+  rescue StandardError
+    flash[:warning] = "You are not authorized to perform this action"
+    redirect_to @idea
+  end
+end

--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -11,20 +11,11 @@ class IdeasController < ApplicationController
       .order(published_at: :desc)
   end
 
-  def viewed
-    idea = Idea.find(params[:idea_id])
-    @views = idea.viewers
-  end
-
   def show
     # TODO: put this check in it's own method like a before_action
     return if logged_in? && current_user.ideas.find_by(id: @idea.id).present?
 
-    Viewer.create!(
-      idea_id: @idea.id,
-      time_viewed: Time.now,
-      viewer_ip: request.remote_ip
-    )
+    Acorn::IdeaViewerService.new(idea: @idea, user: current_user, viewed_at: Time.now, viewer_ip: request.remote_ip).call
   end
 
   def new

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -21,6 +21,16 @@ class Idea < ApplicationRecord
     categories.uniq.map(&:name).join(", ")
   end
 
+  def impression
+    read_attribute(:impression) || 0
+  end
+
+  def increment_impression
+    with_lock do
+      increment!(:impression)
+    end
+  end
+
   private
 
   def save_categories

--- a/app/services/acorn/idea_viewer_service.rb
+++ b/app/services/acorn/idea_viewer_service.rb
@@ -1,0 +1,26 @@
+class Acorn::IdeaViewerService
+  prepend SimpleCommand
+
+  def initialize(idea:, user: nil, viewed_at: Time.now, viewer_ip: request.remote_ip)
+    @idea      = idea
+    @user      = user
+    @viewed_at = viewed_at
+    @viewer_ip = viewer_ip
+  end
+
+  def call
+    create
+  end
+
+  private
+
+  attr_reader :idea, :user, :viewed_at, :viewer_ip
+
+  def create
+    idea.increment_impression
+
+    return if user.present? && Viewer.find_by(user_id: user.id, idea_id: idea.id).present?
+
+    Viewer.create!(idea_id: idea.id, user_id: user&.id, viewed_at: viewed_at, viewer_ip: viewer_ip)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
 
   resources :ideas do
-    get "viewed"
+    resources :viewers, controller: "idea_viewers", only: %i[index show]
     resources :comments
   end
 

--- a/db/migrate/20190210100716_add_impression_to_ideas.rb
+++ b/db/migrate/20190210100716_add_impression_to_ideas.rb
@@ -1,0 +1,5 @@
+class AddImpressionToIdeas < ActiveRecord::Migration[5.1]
+  def change
+    add_column :ideas, :impression, :integer
+  end
+end

--- a/db/migrate/20190210101027_add_user_id_to_viewers.rb
+++ b/db/migrate/20190210101027_add_user_id_to_viewers.rb
@@ -1,0 +1,5 @@
+class AddUserIdToViewers < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :viewers, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20190210103105_rename_column_time_viewed_to_viewed_at.rb
+++ b/db/migrate/20190210103105_rename_column_time_viewed_to_viewed_at.rb
@@ -1,0 +1,5 @@
+class RenameColumnTimeViewedToViewedAt < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :viewers, :time_viewed, :viewed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181128151138) do
+ActiveRecord::Schema.define(version: 20190210103105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20181128151138) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.integer "impression"
     t.index ["user_id"], name: "index_ideas_on_user_id"
   end
 
@@ -93,12 +94,14 @@ ActiveRecord::Schema.define(version: 20181128151138) do
   end
 
   create_table "viewers", force: :cascade do |t|
-    t.datetime "time_viewed"
+    t.datetime "viewed_at"
     t.string "viewer_ip"
     t.bigint "idea_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["idea_id"], name: "index_viewers_on_idea_id"
+    t.index ["user_id"], name: "index_viewers_on_user_id"
   end
 
   add_foreign_key "comments", "ideas"
@@ -107,4 +110,5 @@ ActiveRecord::Schema.define(version: 20181128151138) do
   add_foreign_key "idea_categories", "ideas"
   add_foreign_key "ideas", "users"
   add_foreign_key "viewers", "ideas"
+  add_foreign_key "viewers", "users"
 end

--- a/spec/controllers/ideas_controller_spec.rb
+++ b/spec/controllers/ideas_controller_spec.rb
@@ -71,11 +71,10 @@ RSpec.describe IdeasController, type: :controller do
     end
   end
 
-  describe "GET #viewed" do
+  describe "Viewers" do
     context "when the viewer is the owner of the idea" do
       it "does not record the view on that idea" do
         get_xhr(:show, { id: idea.id })
-        get_xhr(:viewed, { idea_id: idea.id })
         viewers = idea.viewers
 
         expect(response).to be_success
@@ -86,7 +85,6 @@ RSpec.describe IdeasController, type: :controller do
     context "when the viewer is not the owner of the idea" do
       it "records the view on that idea" do
         get_xhr(:show, { id: idea2.id })
-        get_xhr(:viewed, { idea_id: idea2.id })
         viewers = idea2.viewers
 
         expect(response).to be_success

--- a/spec/factories/viewers.rb
+++ b/spec/factories/viewers.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :viewer do
+    viewed_at { Time.now }
+    viewer_ip { Faker::Lorem.sentence }
+    idea
+  end
+end

--- a/spec/integration/idea_viewers_spec.rb
+++ b/spec/integration/idea_viewers_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe IdeaViewersController, type: :request do
+  let!(:user) { create :user }
+  let!(:idea) { create :idea, user: user }
+  let!(:viewer) { create :viewer, idea: idea }
+
+  before do
+    stub_current_user(user)
+  end
+
+  describe "GET #index" do
+    it "returns all views for an idea" do
+      get_xhr(idea_viewers_path({ idea_id: idea.id }))
+      viewers = idea.viewers
+
+      expect(response).to be_success
+      expect(viewers.size).to be 1
+    end
+  end
+
+  describe "GET #show" do
+    it "return a specific viewer for an idea" do
+      get_xhr(idea_viewer_path({ idea_id: idea.id, id: viewer.id }))
+
+      expect(response).to be_success
+    end
+  end
+end

--- a/spec/presenters/idea_presenter_spec.rb
+++ b/spec/presenters/idea_presenter_spec.rb
@@ -61,7 +61,7 @@ describe IdeaPresenter do
     it "returns the date the idea was published" do
       idea.update(published_at: Time.now)
       expect(idea_presenter.publish_date)
-          .to eql "#{ActionView::Helpers::DateHelper.time_ago_in_words(idea.published_at)} ago"
+        .to eql "#{ActionView::Helpers::DateHelper.time_ago_in_words(idea.published_at)} ago"
     end
   end
 

--- a/spec/services/idea_viewer_service_spec.rb
+++ b/spec/services/idea_viewer_service_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe Acorn::IdeaViewerService do
+  let!(:user) { create :user }
+  let!(:idea) { create :idea }
+  let!(:view_params) do
+    {
+      idea: idea,
+      user: user,
+      viewed_at: Time.now,
+      viewer_ip: "127.0.0.1",
+    }
+  end
+
+  describe ".call" do
+    context "when an anonymous user views an idea" do
+      it "records the view for the associated amount of times" do
+        params = {
+          idea: idea,
+          user: nil,
+          viewed_at: Time.now,
+          viewer_ip: "127.0.0.1",
+        }
+        2.times do
+          described_class.new(params).call
+        end
+
+        expect(idea.viewers.size).to be 2
+      end
+
+      it "records the idea impression for the associated amount of times" do
+        params = {
+          idea: idea,
+          user: nil,
+          viewed_at: Time.now,
+          viewer_ip: "127.0.0.1",
+        }
+
+        5.times do
+          described_class.new(params).call
+        end
+
+        expect(idea.impression).to be 5
+      end
+    end
+
+    context "when a known user views an idea" do
+      it "records the view once for umnlimited amount of times" do
+        2.times do
+          described_class.new(view_params).call
+        end
+
+        expect(idea.viewers.size).to be 1
+      end
+
+      it "records the idea impression for the associated amount of times" do
+        params = {
+          idea: idea,
+          user: nil,
+          viewed_at: Time.now,
+          viewer_ip: "127.0.0.1",
+        }
+
+        5.times do
+          described_class.new(params).call
+        end
+
+        expect(idea.impression).to be 5
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
- This PR ensures that view is unique per known user account

#### Description of Task proposed in this pull request?
- ensure views can be recorded for anonymous visitors
- ensure view should be recorded once for known user account
- ensure impression is recorded per user view

#### How should this be manually tested?
- view an idea either as an anonymous or registered user

#### What are the relevant pivotal tracker stories?
- [Story ID:  #161700515](https://www.pivotaltracker.com/story/show/161700515)

#### Any background context you want to add?
- None

#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]
- Learnt how to use the `increment!` to auto increment an active record integer object

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
- None