### PR TITLE
Improve Categories Functionality

### DIFF
--- a/app/assets/javascripts/api/category_api.coffee
+++ b/app/assets/javascripts/api/category_api.coffee
@@ -1,0 +1,9 @@
+class Category.API
+  allCategories: ->
+    return $.ajax(
+      url: "/categories"
+      type: 'GET'
+      dataType: 'json'
+      success: (data) ->
+        return data
+    )

--- a/app/assets/javascripts/global/global.coffee
+++ b/app/assets/javascripts/global/global.coffee
@@ -4,3 +4,4 @@ window.PageUrl = {}
 window.Idea = {}
 window.ConfirmationModal = {}
 window.Header = {}
+window.Category = {}

--- a/app/assets/javascripts/ideas.coffee
+++ b/app/assets/javascripts/ideas.coffee
@@ -4,6 +4,7 @@
 $(document).on 'turbolinks:load', =>
   pageUrl = new PageUrl.App
   currentLocation = pageUrl.start()
+  
   if (currentLocation[2] == 'new' || currentLocation[3] == 'edit')
     newIdea = new Idea.App()
     newIdea.start()
@@ -24,3 +25,6 @@ $(document).on 'turbolinks:load', =>
     }
     confirmationModal.start(confirmContext)
 
+  # Ensure selected categories is only persistent for new and edit idea page
+  if (!currentLocation.includes("edit", "new"))
+    localStorage.setItem("selectedCategories", [])

--- a/app/assets/javascripts/login.coffee
+++ b/app/assets/javascripts/login.coffee
@@ -1,3 +1,0 @@
-$(document).on 'turbolinks:load', =>
-  login = new Login.App()
-  login.start()

--- a/app/assets/javascripts/main/idea_app.coffee
+++ b/app/assets/javascripts/main/idea_app.coffee
@@ -1,7 +1,8 @@
 class Idea.App
   constructor: ->
     @newIdeaUI = new Idea.UI
+    @categoryAPI = new Category.API
 
   start: =>
-    @newIdeaUI.initializeNewIdeaForm()
+    @newIdeaUI.initializeNewIdeaForm(@categoryAPI.allCategories)
     @newIdeaUI.setTagsParameter()

--- a/app/assets/javascripts/ui/idea_ui.coffee
+++ b/app/assets/javascripts/ui/idea_ui.coffee
@@ -2,70 +2,94 @@ class Idea.UI
   constructor: () ->
     @categories = []
     @availableTags = []
-    @showIdeaCategories()
+    @populateIdeaCategories()
     @initializeIdeaDropDown()
+    @regEx = /,\s*/
   
-  initializeNewIdeaForm: () ->
+  initializeNewIdeaForm: (allCategories) ->
     self = @
-    self.availableTags = [
-      "ActionScript",
-      "AppleScript",
-      "Asp",
-      "BASIC",
-      "C",
-      "C++",
-      "Clojure",
-      "COBOL",
-      "ColdFusion",
-      "Erlang",
-      "Fortran",
-      "Groovy",
-      "Haskell",
-      "Java",
-      "JavaScript",
-      "Lisp",
-      "Perl",
-      "PHP",
-      "Python",
-      "Ruby",
-      "Scala",
-      "Scheme"
-    ];
+    allCategories().then(
+      (response) ->
+        for obj in response.data
+          self.availableTags.push(obj["name"])
+        return self.availableTags
 
-    $( "#category_name" ).autocomplete({
-      source: self.availableTags,
-      autoFocus: true,
-      appendTo: ".selector",
-      minLength: 1,
-      position: { my : "left bottom", at: "left top", of: "#category_name" }
-    });
+      (error) ->
+        console.log "nothing was fetched"
+    )
 
-  getIdeaCategories: =>
+    self.persistedCategoryEntries()
+
+    $( "#category_name" )
+      # don't navigate away from the field on tab when selecting an item
+      .on 'keydown', (event) ->
+        if (event.keyCode == $.ui.keyCode.TAB && $(this).autocomplete("instance").menu.active)
+          event.preventDefault();
+      .autocomplete({
+        source: (request, response) =>
+          #delegate back to autocomplete, but extract the last term
+          response($.ui.autocomplete.filter(self.availableTags, request.term.split(self.regEx).pop()));
+        autoFocus: true,
+        appendTo: ".selector",
+        minLength: 1,
+        position: { my : "left bottom", at: "left top", of: "#category_name" }
+        select: ( event, ui ) ->
+          terms = this.value.split(self.regEx); 
+          # remove the current input
+          terms.pop();
+          # add the selected item
+          terms.push( ui.item.value );
+          # add placeholder to get the comma-and-space at the end
+          terms.push( "" );
+          this.value = terms.join( ", " );
+          return false;
+      });
+  
+  selectedCategoryEntries: =>
     categories = []
     $('.mdl-chip__text').each (index, element) ->
       categories.push element.textContent
     return categories
   
-  showIdeaCategories: =>
+  saveToLocalStorage: =>
     self = @
-    categoryNumber = 1
-    $categoryInput = $('input[name="idea[all_categories]"]')
-    $('input[name="idea[all_categories]"]').on 'keydown', (event) ->
-      if event.keyCode == 13
-        newCategory = $('input[name="idea[all_categories]"]').val().trim()
-        allCategories = self.getIdeaCategories()
-        $('input[name="idea[all_categories]"]').val('')
-        if newCategory.length >= 1 && !allCategories.includes("#{newCategory}")
-          $('.category_tags').append """
-            <span class="mdl-chip mdl-chip--deletable acorn_modified_chip" id="category-#{categoryNumber}">
-              <span class="mdl-chip__text">#{newCategory}</span>
+    localStorage.setItem("selectedCategories", self.selectedCategoryEntries())
+
+  renderCategory: (categoryEntries) =>
+    self = @
+    for categoryEntry, index in categoryEntries
+      if categoryEntry == ""
+        return
+      if categoryEntries.length >= 1 && !self.selectedCategoryEntries().includes("#{categoryEntry}")
+        $('.category_tags').append """
+            <span class="mdl-chip mdl-chip--deletable acorn_modified_chip" id="category-#{index}">
+              <span class="mdl-chip__text">#{categoryEntry}</span>
               <button type="button" class="mdl-chip__action"><i class="material-icons remove-chip">close</i></button>
             </span>
             """
+        $("#category-#{index} > button").on 'click', ->
+          $(this).parent().remove()
+          # ensure to update localstorage with the change when user removes a selected entry
+          self.saveToLocalStorage()
 
-          $("#category-#{categoryNumber} > button").on 'click', ->
-            $(this).parent().remove()
-          categoryNumber += 1
+
+  # This method retrieves initially selected categories for page reload
+  persistedCategoryEntries: =>
+    self = @
+    categories = localStorage.getItem("selectedCategories").split(self.regEx)
+    self.renderCategory(categories)
+  
+  populateIdeaCategories: =>
+    self = @
+    $('input[name="idea[all_categories]"]').on 'keydown', (event) ->
+      if event.keyCode == 13
+        newCategoryEntries = $('input[name="idea[all_categories]"]').val().trim().split(self.regEx)
+        # clear out the input field after enter button
+        $('input[name="idea[all_categories]"]').val('')
+        
+        self.renderCategory(newCategoryEntries)
+        # Always persist selected entries when user confirms entry by pushiong enter
+        self.saveToLocalStorage()
     
   initializeIdeaDropDown: =>
     $(document).click (event) ->
@@ -81,5 +105,5 @@ class Idea.UI
   setTagsParameter: () =>
     self = @
     $('#draft_btn, #publish_btn').on 'click', ->
-      $('input[name="idea[all_categories]"]').val(self.getIdeaCategories())
+      $('input[name="idea[all_categories]"]').val(self.selectedCategoryEntries())
   

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,22 @@
+class CategoriesController < ApplicationController
+  before_action :set_category, only: %i[show edit update destroy]
+  def index
+    @categories = Category.all
+
+    render json: { data: @categories }
+  end
+
+  def show; end
+
+  def update; end
+
+  private
+
+  def set_category
+    @category = Catgory.find_by(id: params[:id])
+  end
+
+  def category_params
+    params.require(category).permit(:name, :description)
+  end
+end

--- a/app/controllers/category_controller.rb
+++ b/app/controllers/category_controller.rb
@@ -1,2 +1,0 @@
-class CategoryController < ApplicationController
-end

--- a/app/views/ideas/_form.html.erb
+++ b/app/views/ideas/_form.html.erb
@@ -24,7 +24,7 @@
     <section class="category-section">
       <div class="enter-category-tags">
         <span class="selector"></span>
-        <small><i class="fa fa-asterisk"></i>&nbsp;Add or update tags so the world knows what your idea is about:</small>
+        <small><i class="fa fa-asterisk"></i>&nbsp;Add or update tags: ( hint - push enter after each entry )</small>
         <div class="category_tags"></div>
         <%= form.text_field :all_categories, id: :category_name, placeholder: "Press enter to add one or more tags..." %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,17 +4,16 @@ Rails.application.routes.draw do
   root to: "index#index", as: "index"
 
   # FUTURE: API endpoints
-  namespace :api, path: nil, defaults: { format: :json }, constraints: { subdomain: /^api(-\w+)?$/ } do
-    resources :ideas do
-      get "viewed"
-      resources :comments
-    end
-  end
+  # namespace :api, path: nil, defaults: { format: :json }, constraints: { subdomain: /^api(-\w+)?$/ } do
+  #   resources :ideas
+  # end
 
   resources :ideas do
     resources :viewers, controller: "idea_viewers", only: %i[index show]
     resources :comments
   end
+
+  resources :categories
 
   resources :notifications, only: [:index]
 


### PR DESCRIPTION
#### What does this PR do?

- This PR ensures that users can create ideas with categories that already exist or that they add into the application

#### Description of Task proposed in this pull request?
- ensure categories are retrieved from the database
- ensure autocomplete for categories works in the most flexible way
- ensure users do not loose their selected categories on page refresh

#### How should this be manually tested?

- Go to http://open-idea-station.io:3001/ideas/new

#### What are the relevant pivotal tracker stories?
- [Story ID:  #163842810](https://www.pivotaltracker.com/story/show/163842810)

#### Any background context you want to add?

- None

#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]
- I've how to implement autocomplete for multiple values

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
- None
