### PR TITLE
Add UID to Objects

### DIFF
--- a/app/controllers/ideas_controller.rb
+++ b/app/controllers/ideas_controller.rb
@@ -13,7 +13,7 @@ class IdeasController < ApplicationController
 
   def show
     # TODO: put this check in it's own method like a before_action
-    return if logged_in? && current_user.ideas.find_by(id: @idea.id).present?
+    return if logged_in? && current_user.ideas.find_by_slug_name(@idea.slug_name).present?
 
     Acorn::IdeaViewerService.new(idea: @idea, user: current_user, viewed_at: Time.now, viewer_ip: request.remote_ip).call
   end
@@ -26,7 +26,7 @@ class IdeasController < ApplicationController
     @idea = current_user.ideas.new(idea_params)
     respond_to do |format|
       if @idea.save
-        @idea.update_attributes!("published_at", Time.now) if params[:commit] == "Publish"
+        @idea.update_columns({ published_at: Time.now }) if params[:commit] == "Publish"
         format.html { redirect_to @idea, notice: "Idea was successfully created" }
         format.json { render :show, status: :created, location: @idea }
       else
@@ -68,7 +68,7 @@ class IdeasController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_idea
-    @idea = Idea.find(params[:id])
+    @idea = Idea.find_by_slug_name(params[:id])
   end
 
   # Never trust parameters from the scary internet, only allow the white list

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   def create
     user = User.new(user_params)
 
-    if user.save
+    if user.created?
       @success_message = "Your account was successfully created"
       create_session(session_params)
     else

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,11 @@
 class Category < ApplicationRecord
+  include UniqueIdentifier
+
   has_many :idea_categories, dependent: :destroy
   has_many :ideas, through: :idea_categories
   validates_uniqueness_of :name
+
+  def uid_prefix
+    "cat"
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,8 @@
 class Comment < ApplicationRecord
   ACTION = :commented
 
+  include UniqueIdentifier
+
   include Notifiable
 
   belongs_to :idea
@@ -13,5 +15,9 @@ class Comment < ApplicationRecord
     end
 
     idea_commenters.uniq - [user]
+  end
+
+  def uid_prefix
+    "com"
   end
 end

--- a/app/models/concerns/unique_identifier.rb
+++ b/app/models/concerns/unique_identifier.rb
@@ -9,6 +9,10 @@ module UniqueIdentifier
     before_create :generate_uid
   end
 
+  def to_param
+    uid
+  end
+
   private
 
   # Generate UID for model objects

--- a/app/models/concerns/unique_identifier.rb
+++ b/app/models/concerns/unique_identifier.rb
@@ -1,6 +1,7 @@
 # This is an attempt to use `uid` as a PK compared to auto-incrementing integers
 # see this medium post below:
 # https://tomharrisonjr.com/uuid-or-guid-as-primary-keys-be-careful-7b2aa3dcb439
+require "securerandom"
 module UniqueIdentifier
   extend ActiveSupport::Concern
 
@@ -10,11 +11,14 @@ module UniqueIdentifier
 
   private
 
-  # TODO: create a uid generation module (Acorn::Bubble.generate())
-  # params should include: uid_prefix, size(byte size of generated code), time
+  # Generate UID for model objects
   def generate_uid
     return unless respond_to?(:uid=) # so that we dont have issues running migration scripts
 
-    self.uid = Acorn::Bubble.generate(model_prefix, 96, time = Time.now)
+    self.uid = "#{uid_prefix}_#{normalized_random}"
+  end
+
+  def normalized_random
+    SecureRandom.uuid.split("-").join
   end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -26,8 +26,32 @@ class Idea < ApplicationRecord
     end
   end
 
+  def to_param
+    slug_name
+  end
+
+  # Even when we update an idea name this
+  # should also get updated
+  def save
+    self.slug_name = normalize_name
+
+    super
+  end
+
   def uid_prefix
     "ide"
+  end
+
+  private
+
+  def save_categories
+    @all_categories&.split(",")&.each do |name|
+      categories << Category.where(name: name.strip).first_or_create!
+    end
+  end
+
+  def normalize_name
+    name.downcase.parameterize
   end
 
   concerning :Categories do
@@ -38,14 +62,6 @@ class Idea < ApplicationRecord
 
     def all_categories
       categories.uniq.map(&:name).join(", ")
-    end
-
-    private
-
-    def save_categories
-      @all_categories&.split(",")&.each do |name|
-        categories << Category.where(name: name.strip).first_or_create!
-      end
     end
   end
 end

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,4 +1,6 @@
 class Idea < ApplicationRecord
+  include UniqueIdentifier
+
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :viewers, dependent: :destroy
@@ -22,6 +24,10 @@ class Idea < ApplicationRecord
     with_lock do
       increment!(:impression)
     end
+  end
+
+  def uid_prefix
+    "ide"
   end
 
   concerning :Categories do

--- a/app/models/idea_category.rb
+++ b/app/models/idea_category.rb
@@ -1,4 +1,10 @@
 class IdeaCategory < ApplicationRecord
+  include UniqueIdentifier
+
   belongs_to :idea
   belongs_to :category
+
+  def uid_prefix
+    "idec"
+  end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,10 +1,16 @@
 class Notification < ApplicationRecord
   SIZE = 5
 
+  include UniqueIdentifier
+
   belongs_to :recipient, class_name: "User"
   belongs_to :actor, class_name: "User"
   belongs_to :notifiable, polymorphic: true
 
   scope :unread, -> { where(is_read: false) }
   scope :recent, ->(size) { limit(size || SIZE) }
+
+  def uid_prefix
+    "nof"
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,6 +1,4 @@
 class Session < ApplicationRecord
-  # include UniqueIdentifier
-
   # Device platforms:
   # Key = platform type
   # Value = for how long the session can be used (even if inactive)
@@ -10,6 +8,8 @@ class Session < ApplicationRecord
     browser: 8.hours,
     "": 8.hours,
   }.freeze
+
+  include UniqueIdentifier
 
   belongs_to :user
 
@@ -21,5 +21,9 @@ class Session < ApplicationRecord
 
   def revoke!
     update active: false
+  end
+
+  def uid_prefix
+    "ses"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,10 +42,11 @@ class User < ApplicationRecord
     save
   end
 
-  def save
+  def created?
+    self.email = normalize_email
     self.new_email = email
 
-    super
+    save
   end
 
   def send_email_confirmation
@@ -56,6 +57,12 @@ class User < ApplicationRecord
 
   def uid_prefix
     "usr"
+  end
+
+  private
+
+  def normalize_email
+    email&.strip&.downcase
   end
 
   concerning :Sessions do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   DEFAULT_LOCALE = "en".freeze
   DEFAULT_PROVIDER = "open-idea-station".freeze
 
+  include UniqueIdentifier
+
   has_secure_password
 
   validates :username, presence: true, uniqueness: { case_sensitive: false }, \
@@ -50,6 +52,10 @@ class User < ApplicationRecord
     token = Acorn::JsonWebToken.encode({ data: [id, new_email] }, LINK_VALIDITY.from_now)
 
     UsersMailer.delay.email_confirmation(id, token)
+  end
+
+  def uid_prefix
+    "usr"
   end
 
   concerning :Sessions do

--- a/app/models/viewer.rb
+++ b/app/models/viewer.rb
@@ -1,3 +1,9 @@
 class Viewer < ApplicationRecord
+  include UniqueIdentifier
+
   belongs_to :idea
+
+  def uid_prefix
+    "viw"
+  end
 end

--- a/db/migrate/20190303181451_add_columns_to_ideas.rb
+++ b/db/migrate/20190303181451_add_columns_to_ideas.rb
@@ -1,0 +1,6 @@
+class AddColumnsToIdeas < ActiveRecord::Migration[5.1]
+  def change
+    add_column :ideas, :uid, :string
+    add_column :ideas, :slug_name, :string
+  end
+end

--- a/db/migrate/20190303184431_add_uid_to_tables.rb
+++ b/db/migrate/20190303184431_add_uid_to_tables.rb
@@ -1,0 +1,9 @@
+class AddUidToTables < ActiveRecord::Migration[5.1]
+  def change
+    add_column :categories, :uid, :string
+    add_column :comments, :uid, :string
+    add_column :idea_categories, :uid, :string
+    add_column :notifications, :uid, :string
+    add_column :viewers, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190227181944) do
+ActiveRecord::Schema.define(version: 20190303184431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20190227181944) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uid"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -28,6 +29,7 @@ ActiveRecord::Schema.define(version: 20190227181944) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uid"
     t.index ["idea_id"], name: "index_comments_on_idea_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -37,6 +39,7 @@ ActiveRecord::Schema.define(version: 20190227181944) do
     t.bigint "idea_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uid"
     t.index ["category_id"], name: "index_idea_categories_on_category_id"
     t.index ["idea_id"], name: "index_idea_categories_on_idea_id"
   end
@@ -51,6 +54,8 @@ ActiveRecord::Schema.define(version: 20190227181944) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.integer "impression"
+    t.string "uid"
+    t.string "slug_name"
     t.index ["user_id"], name: "index_ideas_on_user_id"
   end
 
@@ -63,6 +68,7 @@ ActiveRecord::Schema.define(version: 20190227181944) do
     t.bigint "notifiable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uid"
     t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
   end
 
@@ -103,6 +109,7 @@ ActiveRecord::Schema.define(version: 20190227181944) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.string "uid"
     t.index ["idea_id"], name: "index_viewers_on_idea_id"
     t.index ["user_id"], name: "index_viewers_on_user_id"
   end

--- a/spec/controllers/ideas_controller_spec.rb
+++ b/spec/controllers/ideas_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe IdeasController, type: :controller do
   describe "Viewers" do
     context "when the viewer is the owner of the idea" do
       it "does not record the view on that idea" do
-        get_xhr(:show, { id: idea.id })
+        get_xhr(:show, { id: idea.slug_name })
         viewers = idea.viewers
 
         expect(response).to be_success
@@ -84,7 +84,7 @@ RSpec.describe IdeasController, type: :controller do
 
     context "when the viewer is not the owner of the idea" do
       it "records the view on that idea" do
-        get_xhr(:show, { id: idea2.id })
+        get_xhr(:show, { id: idea2.slug_name })
         viewers = idea2.viewers
 
         expect(response).to be_success
@@ -95,15 +95,15 @@ RSpec.describe IdeasController, type: :controller do
 
   describe "GET #edit" do
     it "does not allow an unauthorized user to edit an idea" do
-      get_xhr(:edit, { id: idea2.id })
+      get_xhr(:edit, { id: idea2.slug_name })
 
       expect(response.code).to eql "302"
-      expect(response).to redirect_to(idea_path(idea2.id))
+      expect(response).to redirect_to(idea_path(idea2.slug_name))
       expect(flash[:warning]).to eql "You are not authorized to perform this action"
     end
 
     it "allows an authorized user to edit an idea" do
-      get_xhr(:edit, { id: idea.id })
+      get_xhr(:edit, { id: idea.slug_name })
 
       expect(response).to be_success
     end
@@ -115,7 +115,7 @@ RSpec.describe IdeasController, type: :controller do
         update_params =
           {
             commit: "Publish",
-            id: idea.id,
+            id: idea.slug_name,
             idea: {
               name: "name changed",
               description: "some idea john created for test purpose",
@@ -137,7 +137,7 @@ RSpec.describe IdeasController, type: :controller do
       it "updates the idea, without publishing" do
         update_params =
           {
-            id: idea.id,
+            id: idea.slug_name,
             idea: {
               name: "name changed again",
               description: "some idea john created for test purpose",
@@ -148,9 +148,11 @@ RSpec.describe IdeasController, type: :controller do
           }
         patch_xhr(:update, update_params)
 
-        expect(assigns(:idea).name).to eq "name changed again"
-        expect(response).to redirect_to(idea_path(idea.id))
-        expect(assigns(:idea).published_at).to be nil
+        updated_idea = assigns(:idea)
+
+        expect(updated_idea.name).to eq "name changed again"
+        expect(response).to redirect_to(idea_path(updated_idea))
+        expect(updated_idea.published_at).to be nil
       end
     end
 
@@ -158,7 +160,7 @@ RSpec.describe IdeasController, type: :controller do
       it "does not update the idea" do
         update_params =
           {
-            id: idea2.id,
+            id: idea2.slug_name,
             idea: {
               name: "name won't change",
               description: "some idea john created for test purpose",
@@ -170,7 +172,7 @@ RSpec.describe IdeasController, type: :controller do
         patch_xhr(:update, update_params)
 
         expect(assigns(:idea).name).not_to eq "name won't change"
-        expect(response).to redirect_to(idea_path(idea2.id))
+        expect(response).to redirect_to(idea_path(idea2.slug_name))
         expect(assigns(:idea).published_at).to be nil
         expect(flash[:warning]).to eql "You are not authorized to perform this action"
       end
@@ -180,7 +182,7 @@ RSpec.describe IdeasController, type: :controller do
       it "does not update the idea for invalid parameters" do
         invalid_params =
           {
-            id: idea.id,
+            id: idea.slug_name,
             idea: {
               name: "jo",
             },
@@ -195,15 +197,15 @@ RSpec.describe IdeasController, type: :controller do
 
   describe "PATCH #destroy" do
     it "does not delete another users idea" do
-      delete_xhr(:destroy, { id: idea2.id })
+      delete_xhr(:destroy, { id: idea2.slug_name })
 
-      expect(response).to redirect_to(idea_path(idea2.id))
+      expect(response).to redirect_to(idea_path(idea2.slug_name))
       expect(assigns(:idea).is_archived).to be false
       expect(flash[:warning]).to eql "You are not authorized to perform this action"
     end
 
     it "successfully deletes the authorized user idea" do
-      delete_xhr(:destroy, { id: idea.id })
+      delete_xhr(:destroy, { id: idea.slug_name })
 
       expect(response).to redirect_to(ideas_path)
       expect(assigns(:idea).is_archived).to be true

--- a/spec/factories/ideas.rb
+++ b/spec/factories/ideas.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :idea do
     name { Faker::Name.name }
+    slug_name { name.downcase.parameterize }
     description { Faker::Lorem.sentence }
     url { Faker::Internet.url }
     user


### PR DESCRIPTION
#### What does this PR do?

- This PR ensure that `uids` are generated for objects and this uids are used will be used find the object

#### Description of Task proposed in this pull request?

- Ensure uids are generated and persisted on object creation
- Ensure idea name slug is used in url for an idea
- Ensure uid will be used for all othe object types
- Ensure emails are normalized for a user 

#### How should this be manually tested?
- create an idea, or a new user

#### What are the relevant pivotal tracker stories?
- None

#### Any background context you want to add?
- None

#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]

- Learn how rails customises default ids added to urls to the `to_param` instance method

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
- None
