### PR TITLE
Move Realtime Notification Dispatch to Background Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "jbuilder", "~> 2.5"
 
 # Background job processing
 gem "redis", "~> 3.0"
-gem 'sidekiq'
+gem "sidekiq"
 
 # Use ActiveModel has_secure_password
 gem "bcrypt", "~> 3.1.7"

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq -q default -q mailers -q urgent,2
+worker: bundle exec sidekiq -t 25 -c 5 -q default -q mailers -q urgent,2

--- a/app/models/concerns/notifiable.rb
+++ b/app/models/concerns/notifiable.rb
@@ -29,7 +29,7 @@ module Notifiable
       recipients << { recipient: recipient[:username] }
     end
 
-    ::NotificationBroadcastJob.new.perform(recipients, broadcast_content)
+    ::NotificationBroadcastJob.perform_later(recipients, broadcast_content)
   end
 
   private

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://127.0.0.1:6379/1
 
 test:
   adapter: async


### PR DESCRIPTION
#### What does this PR do?

After adding a background processing application, we think it would be better to also move notification broadcast into a background job. This PR ensures realtime notification does not run on the same thread as our web application