### PR TITLE
Add Views for Email Confirmations

### DIFF
--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,13 +1,38 @@
 class EmailConfirmationsController < ApplicationController
+  skip_before_action :authorize, only: %i[new create edit update]
+
+  def new; end
+
   def create
+    user = User.find_by_new_email(email_confirmation_params[:email])
     respond_to do |format|
-      unless current_user.new_email.present?
-        flash[:notice] = I18n.t("email_confirmations.already_confirmed")
-        format.html { redirect_to ideas_path }
+      unless user.present?
+        flash[:notice] = "Email does not exist or has already been confirmed"
+        format.html { redirect_to new_session_path }
         return
       end
 
-      current_user.send_email_confirmation
+      user.send_email_confirmation
+      flash[:notice] = "We have resent a confirmation email to your inbox"
     end
+  end
+
+  def edit; end
+
+  def update
+    user = User.find_by_email_confirmation_token(params[:token])
+    if user
+      user.confirm_email
+      flash[:success] = "You have successfully confirmed your email"
+    else
+      flash[:success] = "Link is invalid. It may have expired or have already been used"
+    end
+    redirect_to new_session_path
+  end
+
+  private
+
+  def email_confirmation_params
+    params.require(:email_confirmation).permit(:email)
   end
 end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -33,7 +33,7 @@ class EmailConfirmationsController < ApplicationController
       flash[:success] = "Email successfully confirmed. Please sign in to continue"
       redirect_to new_session_path
     else
-      flash[:success] = "Link is invalid. It may have expired or have already been used"
+      flash[:notice] = "Link is invalid. It may have expired or have already been used"
       redirect_to new_email_confirmation_path
     end
   end

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,38 +1,51 @@
 class EmailConfirmationsController < ApplicationController
   skip_before_action :authorize, only: %i[new create edit update]
+  before_action :redirect_logged_in_user
 
   def new; end
 
   def create
-    user = User.find_by_new_email(email_confirmation_params[:email])
     respond_to do |format|
-      unless user.present?
-        flash[:notice] = "Email does not exist or has already been confirmed"
-        format.html { redirect_to new_session_path }
-        return
-      end
+      if email_confirmation_params[:email].present? && email_confirmation_params[:email].match(User::EMAIL_REGEX)
+        user = User.find_by_new_email(email_confirmation_params[:email])
+        if user.present?
+          user.send_email_confirmation
+          flash[:notice] = "We have resent a confirmation email to your inbox"
+        else
+          flash[:notice] = "Email does not exist or has already been confirmed"
+        end
 
-      user.send_email_confirmation
-      flash[:notice] = "We have resent a confirmation email to your inbox"
+        format.html { redirect_to new_session_path }
+      else
+        flash[:error] = "Please enter a valid email address"
+
+        format.html { redirect_to new_email_confirmation_path }
+      end
     end
   end
 
   def edit; end
 
   def update
-    user = User.find_by_email_confirmation_token(params[:token])
+    user = User.find_by_email_confirmation_token(params[:token].to_s)
     if user
       user.confirm_email
-      flash[:success] = "You have successfully confirmed your email"
+      flash[:success] = "Email successfully confirmed. Please sign in to continue"
+      redirect_to new_session_path
     else
       flash[:success] = "Link is invalid. It may have expired or have already been used"
+      redirect_to new_email_confirmation_path
     end
-    redirect_to new_session_path
   end
 
   private
 
   def email_confirmation_params
     params.require(:email_confirmation).permit(:email)
+  end
+
+  # Ensure logged in users do not interract with email_confirmations actions
+  def redirect_logged_in_user
+    redirect_to ideas_path if logged_in?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,14 @@ class User < ApplicationRecord
     session&.user
   end
 
+  def self.find_by_email_confirmation_token(token)
+    decoded_token = Acorn::JsonWebToken.decode(token)
+    return nil unless decoded_token
+
+    id, new_email = decoded_token[:data]
+    find_by(id: id, new_email: new_email)
+  end
+
   def bio
     read_attribute(:bio) || "Bio is yet to be updated"
   end

--- a/app/views/email_confirmations/edit.html.haml
+++ b/app/views/email_confirmations/edit.html.haml
@@ -1,0 +1,7 @@
+#user
+  %section.user-form
+    .title
+      %h6 Email Confirmation
+    .body
+      %p Click the button below to complete the process of confirming your email
+      =link_to "Confirm email", email_confirmation_path, method: :patch, class: "acorn_btn get-started"

--- a/app/views/email_confirmations/new.html.haml
+++ b/app/views/email_confirmations/new.html.haml
@@ -1,0 +1,12 @@
+#user
+  %section.user-form
+    .title
+      %h6 Send Email Confirmation
+    .body
+      =form_with scope: :email_confirmation, url: email_confirmations_path, local: true , id: :global do |form|
+        .field.for-data.group
+          %label Email
+          =form.text_field :email, id: :email, placeholder: 'enter your email'
+        .field.group
+          %span.actions
+            =form.submit "Send mail"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,9 +41,6 @@ Rails.application.routes.draw do
     end
   end
   # Email confirmation
-  resources :email_confirmations, only: %i[new create update], param: :token do
-    collection do
-      get "/:token", to: "email_confirmations#edit", as: "edit"
-    end
-  end
+  resources :email_confirmations, only: %i[new create update], param: :token
+  get "email_confirmations/:token", to: "email_confirmations#edit"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,5 +41,9 @@ Rails.application.routes.draw do
     end
   end
   # Email confirmation
-  resources :email_confirmations, only: %i[create edit update], param: :token
+  resources :email_confirmations, only: %i[new create update], param: :token do
+    collection do
+      get "/:token", to: "email_confirmations#edit", as: "edit"
+    end
+  end
 end


### PR DESCRIPTION
#### What does this PR do?

- This PR add the views for confirmation email and resending email confirmation for a user

#### Description of Task proposed in this pull request?
- ensure users can confirm email
- ensure user can request for confirmation mail

#### How should this be manually tested?

- Go to `http://open-idea-station.io:3001/email_confirmations/new` for requesting email confirmation
- Go to `http://open-idea-station.io:3001/email_confirmations/token_provided_in_email`


#### What are the relevant pivotal tracker stories?

- None

#### Any background context you want to add?

- None

#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]

- I've learned that certain kind of views should be displayed according to the user status logged_in or anonymous

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]

<img width="841" alt="Screen Shot 2019-03-13 at 9 48 45 PM" src="https://user-images.githubusercontent.com/13672476/54313533-de38e080-45d9-11e9-9101-c245258a0beb.png">

<img width="847" alt="Screen Shot 2019-03-13 at 9 30 24 PM" src="https://user-images.githubusercontent.com/13672476/54313552-e98c0c00-45d9-11e9-8e2c-67294f571389.png">


