### PR TITLE
Add Reset Password Functionality

### DIFF
--- a/app/assets/javascripts/flash.coffee
+++ b/app/assets/javascripts/flash.coffee
@@ -1,0 +1,2 @@
+$(document).on 'turbolinks:load', =>
+  $(".alert").delay(3000).fadeOut(1000)

--- a/app/assets/javascripts/ui/header_ui.coffee
+++ b/app/assets/javascripts/ui/header_ui.coffee
@@ -48,7 +48,7 @@ class Header.UI
       $pageTray = $('#page-tray')
       $mainNav = $('.main-nav')
       scroll = $(window).scrollTop()
-      if scroll >= 160
+      if scroll >= 200
         $pageTray.addClass 'fixed'
         $mainNav.removeClass 'no-shadow'
       else

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -27,7 +27,7 @@ class EmailConfirmationsController < ApplicationController
   def edit; end
 
   def update
-    user = User.find_by_email_confirmation_token(params[:token].to_s)
+    user = User.find_by_email_token(params[:token].to_s, :email_confirmation)
     if user
       user.confirm_email
       flash[:success] = "Email successfully confirmed. Please sign in to continue"

--- a/app/controllers/reset_passwords_controller.rb
+++ b/app/controllers/reset_passwords_controller.rb
@@ -1,0 +1,65 @@
+class ResetPasswordsController < ApplicationController
+  skip_before_action :authorize
+  before_action :redirect_logged_in_user, only: %i[new create edit]
+
+  def new; end
+
+  def create
+    respond_to do |format|
+      if reset_password_params[:email].present? && reset_password_params[:email].match(User::EMAIL_REGEX)
+        user = User.find_by_email(reset_password_params[:email])
+
+        if user.present?
+          user.send_reset_password_email
+          flash[:notice] = "We have sent a password reset link to your inbox"
+        else
+          flash[:notice] = "Email does not exist in our record"
+        end
+
+        format.html { redirect_to new_session_path }
+      else
+        flash[:error] = "Please enter a valid email address"
+        format.html { redirect_to new_reset_password_path }
+      end
+    end
+  end
+
+  def edit; end
+
+  def update
+    user = if logged_in?
+             current_user
+           else
+             User.find_by_email_token(params[:token].to_s, :reset_password)
+           end
+
+    if user.nil?
+      flash[:error] = "Link is invalid. It may have expired or have already been used"
+      redirect_to new_session_path
+    elsif user.change_password(reset_password_params.except(:email))
+      user.send_reset_password_success_mail
+      flash[:notice] = "You have successfully reset your password"
+      redirect_to new_session_path
+    else
+      flash[:error] = user.errors.full_messages[0]
+      redirect_to change_password_path
+    end
+
+    # Sign out all sessions for logged_in user
+    # let user re-authenticate
+    current_user&.revoke_all_sessions!
+  end
+
+  private
+
+  def reset_password_params
+    params.require(:reset_password).permit(
+      :email, :password, :password_confirmation
+    )
+  end
+
+  # Ensure logged in users do not interract with requesting new password via email
+  def redirect_logged_in_user
+    redirect_to ideas_path if logged_in?
+  end
+end

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -7,4 +7,13 @@ class UsersMailer < ApplicationMailer
       mail to: "#{@user.username} <#{@user.email}>", subject: subject
     end
   end
+
+  def reset_password(user_id, token)
+    @user = User.find_by(id: user_id)
+    @token = token
+
+    send_mail_with_user_locale(@user.locale) do
+      mail to: "#{@user.username} <#{@user.email}>", subject: subject
+    end
+  end
 end

--- a/app/models/reset_password.rb
+++ b/app/models/reset_password.rb
@@ -1,0 +1,3 @@
+class ResetPassword < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   USERNAME_REGEX = /\A[a-zA-Z0-9_]+\Z/.freeze
   EMAIL_REGEX = /\A\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,4})\z/i.freeze
   LINK_VALIDITY = 2.hours
+  RESET_LINK_VALIDITY = 1.hour
   DEFAULT_LOCALE = "en".freeze
   DEFAULT_PROVIDER = "open-idea-station".freeze
 
@@ -25,14 +26,26 @@ class User < ApplicationRecord
     session&.user
   end
 
-  def self.find_by_email_confirmation_token(token)
+  def self.find_by_email_token(token, purpose)
     return nil unless token.present?
 
-    id, new_email, expiry = Acorn::Bubble.verify(token)
+    id, email, expiry = Acorn::Bubble.verify(token)
 
     return nil unless expiry.present? && expiry > Time.now
 
-    find_by(id: id, new_email: new_email)
+    user =  if purpose.to_sym == :email_confirmation
+              find_by(id: id, new_email: email)
+            else
+              find_by(id: id, email: email)
+            end
+
+    return nil unless user.find_reset_password_by_token(token).present?
+
+    user
+  end
+
+  def uid_prefix
+    "usr"
   end
 
   def bio
@@ -58,21 +71,53 @@ class User < ApplicationRecord
     save
   end
 
-  def send_email_confirmation
-    token = Acorn::Bubble.generate([id, new_email])
+  concerning :EmailConfirmations do
+    def send_email_confirmation
+      token = Acorn::Bubble.generate([id, new_email])
 
-    UsersMailer.email_confirmation(id, token).deliver_later
+      UsersMailer.email_confirmation(id, token).deliver_later
+    end
+
+    def confirm_email
+      self.email = new_email unless new_email.blank?
+      self.email_confirmed = true
+      self.new_email = nil
+      save
+    end
   end
 
-  def confirm_email
-    self.email = new_email unless new_email.blank?
-    self.email_confirmed = true
-    self.new_email = nil
-    save
-  end
+  concerning :ResetPasswords do
+    included do
+      has_many :reset_passwords, dependent: :destroy
+    end
 
-  def uid_prefix
-    "usr"
+    def all_reset_passwords
+      reset_passwords.order(created_at: :desc)
+    end
+
+    def find_reset_password_by_token(token)
+      all_reset_passwords.find_by(token: token)
+    end
+
+    def change_password(password_attributes)
+      if update(password_attributes.merge({ password_changed_at: Time.zone.now }))
+        all_reset_passwords.each(&:destroy)
+        true
+      else
+        false
+      end
+    end
+
+    def send_reset_password_email
+      token = Acorn::Bubble.generate([id, email], RESET_LINK_VALIDITY)
+      reset_passwords.create(token: token)
+
+      UsersMailer.reset_password(id, token).deliver_later
+    end
+
+    def send_reset_password_success_mail
+      true
+    end
   end
 
   concerning :Sessions do

--- a/app/views/reset_passwords/edit.html.haml
+++ b/app/views/reset_passwords/edit.html.haml
@@ -1,0 +1,15 @@
+#user
+  %section.user-form
+    .title
+      %h6 Change Password
+    .body
+      =form_with scope: :reset_password, url: reset_password_path, method: :patch, local: true , id: :global do |form|
+        .field.for-data.group
+          %label Password
+          =form.password_field :password, id: :password, placeholder: 'enter new password'
+        .field.for-data.group
+          %label Confirm Password
+          =form.password_field :password_confirmation, id: :password_confirmation, placeholder: 're-enter new password'
+        .field.group
+          %span.actions
+            =form.submit "Reset password"

--- a/app/views/reset_passwords/new.html.haml
+++ b/app/views/reset_passwords/new.html.haml
@@ -1,0 +1,12 @@
+#user
+  %section.user-form
+    .title
+      %h6 Rquest New Password
+    .body
+      =form_with scope: :reset_password, url: reset_passwords_path, local: true , id: :global do |form|
+        .field.for-data.group
+          %label Email
+          =form.text_field :email, id: :email, placeholder: 'enter your email'
+        .field.group
+          %span.actions
+            =form.submit "Send reset link"

--- a/app/views/reset_passwords/new.html.haml
+++ b/app/views/reset_passwords/new.html.haml
@@ -1,7 +1,7 @@
 #user
   %section.user-form
     .title
-      %h6 Rquest New Password
+      %h6 Request New Password
     .body
       =form_with scope: :reset_password, url: reset_passwords_path, local: true , id: :global do |form|
         .field.for-data.group

--- a/app/views/users_mailer/reset_password.html.haml
+++ b/app/views/users_mailer/reset_password.html.haml
@@ -1,0 +1,6 @@
+%p.hello= t(".hello", username: @user.username)
+%p= t(".intro")
+%p= t(".body1", time: l(User::LINK_VALIDITY.from_now))
+%p= link_to t(".action"), reset_password_url(@token), class: "acorn_btn email"
+%p= t(".alternative")
+%p.token= link_to reset_password_url(@token), reset_password_url(@token)

--- a/app/views/users_mailer/reset_password.text.erb
+++ b/app/views/users_mailer/reset_password.text.erb
@@ -1,0 +1,14 @@
+<%# Don’t use Haml for plain text email templates. ERB is actually a little
+easier and doesn’t lose line breaks. Try it and see. %>
+
+<%= t(".hello", username: @user.username) %>
+
+<%= t(".intro") %>
+
+<%= t(".body1", time: distance_of_time_in_words(User::LINK_VALIDITY)) %>
+
+<%= reset_password_url(@token) %>
+
+<%= t(".body2") %>
+
+<%= t(".signature") %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,4 +71,6 @@ Rails.application.configure do
 
   # Setup action cable default URL
   config.action_cable.url = ENV["ACTION_CABLE_URL"]
+  # Stop action cable from logging to stdout
+  ActionCable.server.config.logger = Logger.new(nil)
 end

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -18,6 +18,17 @@ en:
       alternative: "If you cannot click the link, please visit the following link to confirm your email."
       body2: ""
       signature: "open idea station"
+    reset_password:
+      subject: "[OIS] Reset Your Password"
+      hello: "Hello %{username},"
+      intro: "You recently requested for a new password to your Open Idea Station account"
+      body1: |
+        If indeed you can't remember your password, please click the button to change your password.
+        Note that this link will be valid until %{time}.
+      action: "Reset Password"
+      alternative: "If you cannot click the link, please visit the following link to change your password."
+      body2: ""
+      signature: "open idea station"
   layouts:
     mailer:
       body:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,4 +43,7 @@ Rails.application.routes.draw do
   # Email confirmation
   resources :email_confirmations, only: %i[new create update], param: :token
   get "email_confirmations/:token", to: "email_confirmations#edit"
+  # Reset Password
+  resources :reset_passwords, only: %i[new create update], param: :token
+  get "reset_passwords/:token", to: "reset_passwords#edit", as: :change_password
 end

--- a/db/migrate/20190314204223_add_columns_to_users.rb
+++ b/db/migrate/20190314204223_add_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :password_changed_at, :datetime
+    add_column :users, :admin, :boolean
+  end
+end

--- a/db/migrate/20190322180933_create_reset_passwords.rb
+++ b/db/migrate/20190322180933_create_reset_passwords.rb
@@ -1,0 +1,10 @@
+class CreateResetPasswords < ActiveRecord::Migration[5.1]
+  def change
+    create_table :reset_passwords do |t|
+      t.string :token
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190303184431) do
+ActiveRecord::Schema.define(version: 20190314204223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,8 @@ ActiveRecord::Schema.define(version: 20190303184431) do
     t.boolean "email_confirmed", default: false
     t.string "new_email"
     t.string "locale"
+    t.datetime "password_changed_at"
+    t.boolean "admin"
   end
 
   create_table "viewers", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190314204223) do
+ActiveRecord::Schema.define(version: 20190322180933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,14 @@ ActiveRecord::Schema.define(version: 20190314204223) do
     t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable_type_and_notifiable_id"
   end
 
+  create_table "reset_passwords", force: :cascade do |t|
+    t.string "token"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_reset_passwords_on_user_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.bigint "user_id"
     t.boolean "active"
@@ -121,6 +129,7 @@ ActiveRecord::Schema.define(version: 20190314204223) do
   add_foreign_key "idea_categories", "categories"
   add_foreign_key "idea_categories", "ideas"
   add_foreign_key "ideas", "users"
+  add_foreign_key "reset_passwords", "users"
   add_foreign_key "viewers", "ideas"
   add_foreign_key "viewers", "users"
 end

--- a/lib/acorn/bubble.rb
+++ b/lib/acorn/bubble.rb
@@ -7,7 +7,7 @@ module Acorn
 
     # Public: generate recieves an array as argument
     def generate(payload, expiry = nil)
-      verifier.generate(payload << (expiry || EXPIRY))
+      verifier.generate(payload << (expiry.from_now || EXPIRY))
     end
 
     def verify(token)

--- a/spec/mailers/previews/users_mailer_preview.rb
+++ b/spec/mailers/previews/users_mailer_preview.rb
@@ -9,4 +9,10 @@ class UsersMailerPreview < ActionMailer::Preview
 
     UsersMailer.email_confirmation(@user.id, token)
   end
+
+  def reset_password
+    token = Acorn::Bubble.generate([@user.id, @user.email], 1.hour.from_now)
+
+    UsersMailer.reset_password(@user.id, token)
+  end
 end

--- a/spec/models/reset_password_spec.rb
+++ b/spec/models/reset_password_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ResetPassword, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/models/reset_password_spec.rb
+++ b/spec/models/reset_password_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ResetPassword, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#### What does this PR do?

- This PR ensures users can request for a new password securely

#### Description of Task proposed in this pull request?

- Add migration script with introduced `admin` and `password_changed_at` columns to the `user` table
- Add `reset_password` model to manage user tokens
- Ensure users can see a password reset form
- Ensure users receive email link for changing password
- Ensure users can change password
- Ensure logged in user can change password
- Ensure logged in user does not access reset password forms

#### How should this be manually tested?

- Goto http://open-idea-station.io:3001/reset_password/new
- Click link in email, and change password.

#### What are the relevant pivotal tracker stories?

- [Story ID: #164646107](https://www.pivotaltracker.com/story/show/164646107)

#### Any background context you want to add?

- None.

#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]

- It is important to allow a user know the last time they changed their password
- It's also important to have a table that you can use to keep track of used token

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]

- Request new password:
<img width="1044" alt="Screen Shot 2019-03-23 at 1 55 58 PM" src="https://user-images.githubusercontent.com/13672476/54866410-a5380300-4d73-11e9-89dc-10aba0e589b6.png">

- Change Password
<img width="946" alt="Screen Shot 2019-03-23 at 1 56 23 PM" src="https://user-images.githubusercontent.com/13672476/54866418-b41eb580-4d73-11e9-8b20-f6cda27885d6.png">

