### PR TITLE
Add User Management Links

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -106,3 +106,14 @@
     }
   }
 }
+
+.user-management-links {
+  padding: 20px;
+  font-size: 1.2rem;
+  a:hover {
+    color: $green;
+  }
+  .new-user, .new-email-confirmation {
+    margin-left: 10px;
+  }
+}

--- a/app/views/sessions/_login_form.html.haml
+++ b/app/views/sessions/_login_form.html.haml
@@ -9,3 +9,12 @@
   .field.group
     %span.actions
       =form.submit "Log in"
+
+  -# User management links
+  .field.group.user-management-links
+    =link_to new_reset_password_path, class: "forgot-password" do
+      %i.fa.fa-asterisk
+      Forgot password?
+    =link_to new_user_path, class: "new-user" do
+      %i.fa.fa-asterisk
+      Don't have an account?

--- a/app/views/users/_signup_form.html.haml
+++ b/app/views/users/_signup_form.html.haml
@@ -16,3 +16,12 @@
   .field.group
     %span.actions
       =form.submit "Sign up"
+
+  -# User management links
+  .field.group.user-management-links
+    =link_to new_session_path, class: "new-session" do
+      %i.fa.fa-asterisk
+      Already have an account?
+    =link_to new_email_confirmation_path, class: "new-email-confirmation" do
+      %i.fa.fa-asterisk
+      Resend email confirmation link?


### PR DESCRIPTION
#### What does this PR do?
- This PR add important links around signin and signup forms to help users access important pages

#### Description of Task proposed in this pull request?
- add  link to help user request new password
- add link to help user resend email confirmation mail
- add link to take users to signup or signing page

#### How should this be manually tested?
- Goto `http://open-idea-station.io:3001/sessions/new` and `http://open-idea-station.io:3001/users/new`


#### What are the relevant pivotal tracker stories?
- [Story ID:  #164846993](https://www.pivotaltracker.com/story/show/164846993)

#### Any background context you want to add?
- None
#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]
- Importance of good user experience.

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
- 
<img width="843" alt="Screen Shot 2019-03-23 at 3 12 54 PM" src="https://user-images.githubusercontent.com/13672476/54867240-462bbb80-4d7e-11e9-9047-b31db5ee749f.png">
<img width="752" alt="Screen Shot 2019-03-23 at 3 12 43 PM" src="https://user-images.githubusercontent.com/13672476/54867261-8428df80-4d7e-11e9-9aee-1efeeac66bd3.png">


