### PR TITLE
Use Slug Name for Idea URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "jbuilder", "~> 2.5"
 
 # Background job processing
 gem "redis", "~> 3.0"
+gem "redis-namespace"
 gem "sidekiq"
 
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,8 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.4.0)
     redis (3.3.5)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (3.8.0)
@@ -449,6 +451,7 @@ DEPENDENCIES
   rails-controller-testing
   redcarpet
   redis (~> 3.0)
+  redis-namespace
   rspec-rails (~> 3.5)
   rubocop
   rubyzip (>= 1.2.1)

--- a/app/models/slug.rb
+++ b/app/models/slug.rb
@@ -1,0 +1,42 @@
+# This is an attempt to use custom names instead of integer ids as part of
+# our URL `uid`
+class Slug
+  class << self
+    def [](slug)
+      redis.hget(hash, slug)
+    end
+
+    # Every post id will have an associated set whose members are
+    # the slugs which map to that post id.
+    # That is, whenever we map a slug to a post id, we will also add
+    # that slug to the set of slugs associated with that post id.
+    # Moreover, as it is possible to update a slug to point to a different
+    # post id, we will first need to remove that slug from the set of
+    # slugs for the old post id.
+    def []=(slug, id)
+      old = self[slug]
+      redis.srem(set(old), slug) if old
+      redis.hset(hash, slug, id)
+      redis.sadd(set(id), slug)
+    end
+
+    def destroy(id)
+      redis.smembers(set(id)).each { |slug| redis.hdel(hash, slug) }
+      redis.del(set(id))
+    end
+
+    private
+
+    def redis
+      Acorn::InitRedis::Start
+    end
+
+    def hash
+      "idea_ids"
+    end
+
+    def set(id)
+      "idea_slugs_#{id}"
+    end
+  end
+end

--- a/config/initializers/init_redis.rb
+++ b/config/initializers/init_redis.rb
@@ -1,0 +1,5 @@
+module Acorn
+  class InitRedis
+    Start ||= Redis::Namespace.new("acorn", { redis: Redis.new })
+  end
+end


### PR DESCRIPTION
#### What does this PR do?
- Initially we used idea ids in the URL for viewing ideas, which isn't really cool as it shows the amount of ideas we currently have in our database. Now, we have decided to change that and use slug names. The benefit of using slug names is to ensure our URLs reads nicely and we can leverage Redis to ensure that even when an idea owner changes the slug name for an idea, old URLs referencing the idea would still link successfully.

#### Description of Task proposed in this pull request?
- Add Slug class to help us save, retrieve and delete slugs
- Update Ideas model to keep track of changes to slug name and avoid duplication
- update ideas_controller to retrieve slug from Redis or fallback to db

#### How should this be manually tested?
- Create a new Idea and see the URL of the idea won't be a number

#### What are the relevant pivotal tracker stories?
- None

#### Any background context you want to add?
- None

#### What I have learned working on this feature: [If you don't put anything here, you are doing it wrong!]
- Working with some datatypes in redis.

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
- None
